### PR TITLE
feat(tracing,feedback): fix notification close, feedback comments, N8…

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1739,6 +1739,7 @@ export interface FeedbackStatsResponse {
   score: number | null;
   reason_breakdown: ReasonBreakdownEntry[];
   recent_negative: RecentFeedbackEntry[];
+  recent_positive?: RecentFeedbackEntry[];
   timeline: FeedbackTimelineEntry[];
 }
 

--- a/src/components/chat/ChatContent/ChatContent.tsx
+++ b/src/components/chat/ChatContent/ChatContent.tsx
@@ -553,6 +553,7 @@ const MessageBubble: FC<MessageBubbleProps> = ({
   const [editContent, setEditContent] = useState(content);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [feedbackDialogOpen, setFeedbackDialogOpen] = useState(false);
+  const [feedbackSentiment, setFeedbackSentiment] = useState<'positive' | 'negative'>('negative');
   const [persistedReasoningExpanded, setPersistedReasoningExpanded] = useState(false);
 
   const hasActiveReActSteps = !!reActState && reActState.reasoningSteps.length > 0;
@@ -753,7 +754,14 @@ const MessageBubble: FC<MessageBubbleProps> = ({
                       size="md"
                       variant="subtle"
                       color={activeReaction?.reaction === 'thumbs_up' ? 'teal' : 'gray'}
-                      onClick={() => onReaction(message.id, 'thumbs_up')}
+                      onClick={() => {
+                        if (activeReaction?.reaction === 'thumbs_up') {
+                          onReaction(message.id, 'thumbs_up');
+                        } else {
+                          setFeedbackSentiment('positive');
+                          setFeedbackDialogOpen(true);
+                        }
+                      }}
                     >
                       {activeReaction?.reaction === 'thumbs_up' ? <IconThumbUpFilled size={20} /> : <IconThumbUp size={20} />}
                     </ActionIcon>
@@ -767,6 +775,7 @@ const MessageBubble: FC<MessageBubbleProps> = ({
                         if (activeReaction?.reaction === 'thumbs_down') {
                           onReaction(message.id, 'thumbs_down');
                         } else {
+                          setFeedbackSentiment('negative');
                           setFeedbackDialogOpen(true);
                         }
                       }}
@@ -780,9 +789,15 @@ const MessageBubble: FC<MessageBubbleProps> = ({
           )}
           <FeedbackDialog
             opened={feedbackDialogOpen}
+            sentiment={feedbackSentiment}
             onClose={() => setFeedbackDialogOpen(false)}
             onSubmit={(feedbackText: string | undefined, reasons: string[] | undefined) => {
-              onReaction?.(message.id, 'thumbs_down', feedbackText, reasons);
+              onReaction?.(
+                message.id,
+                feedbackSentiment === 'positive' ? 'thumbs_up' : 'thumbs_down',
+                feedbackText,
+                reasons,
+              );
               setFeedbackDialogOpen(false);
             }}
           />

--- a/src/components/chat/FeedbackDialog/FeedbackDialog.tsx
+++ b/src/components/chat/FeedbackDialog/FeedbackDialog.tsx
@@ -1,10 +1,12 @@
 import type { FC } from 'react';
 import { useState } from 'react';
 import { Modal, Textarea, Group, Button, Stack, Text, ThemeIcon, Chip } from '@mantine/core';
-import { IconThumbDown } from '@tabler/icons-react';
+import { IconThumbDown, IconThumbUp } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
 
-const FEEDBACK_REASONS: { value: string; label: string }[] = [
+export type FeedbackSentiment = 'positive' | 'negative';
+
+const NEGATIVE_FEEDBACK_REASONS: { value: string; label: string }[] = [
   { value: 'INACCURATE', label: 'inaccurate' },
   { value: 'HALLUCINATION', label: 'hallucination' },
   { value: 'INCOMPLETE', label: 'incomplete' },
@@ -14,20 +16,39 @@ const FEEDBACK_REASONS: { value: string; label: string }[] = [
   { value: 'OTHER', label: 'other' },
 ];
 
+const POSITIVE_FEEDBACK_REASONS: { value: string; label: string }[] = [
+  { value: 'ACCURATE', label: 'accurate' },
+  { value: 'HELPFUL', label: 'helpful' },
+  { value: 'COMPLETE', label: 'complete' },
+  { value: 'WELL_FORMATTED', label: 'well formatted' },
+  { value: 'FAST', label: 'fast' },
+  { value: 'OTHER', label: 'other' },
+];
+
 export interface FeedbackDialogProps {
   opened: boolean;
   onClose: () => void;
   onSubmit: (feedbackText?: string, reasons?: string[]) => void;
+  sentiment?: FeedbackSentiment;
 }
 
 export const FeedbackDialog: FC<FeedbackDialogProps> = ({
   opened,
   onClose,
   onSubmit,
+  sentiment = 'negative',
 }) => {
   const { t } = useTranslation();
   const [feedbackText, setFeedbackText] = useState('');
   const [reasons, setReasons] = useState<string[]>([]);
+
+  const isPositive = sentiment === 'positive';
+  const feedbackReasons = isPositive ? POSITIVE_FEEDBACK_REASONS : NEGATIVE_FEEDBACK_REASONS;
+  const accentColor = isPositive ? 'teal' : 'orange';
+  const titleKey = isPositive ? 'conversations:feedbackTitlePositive' : 'conversations:feedbackTitle';
+  const descriptionKey = isPositive
+    ? 'conversations:feedbackDescriptionPositive'
+    : 'conversations:feedbackDescription';
 
   const handleSubmit = () => {
     onSubmit(feedbackText.trim() || undefined, reasons.length > 0 ? reasons : undefined);
@@ -48,10 +69,10 @@ export const FeedbackDialog: FC<FeedbackDialogProps> = ({
       onClose={handleClose}
       title={
         <Group gap="sm">
-          <ThemeIcon size="md" color="orange" variant="light" radius="xl">
-            <IconThumbDown size={16} />
+          <ThemeIcon size="md" color={accentColor} variant="light" radius="xl">
+            {isPositive ? <IconThumbUp size={16} /> : <IconThumbDown size={16} />}
           </ThemeIcon>
-          <Text fw={600}>{t('conversations:feedbackTitle')}</Text>
+          <Text fw={600}>{t(titleKey)}</Text>
         </Group>
       }
       size="md"
@@ -59,13 +80,13 @@ export const FeedbackDialog: FC<FeedbackDialogProps> = ({
     >
       <Stack gap="md">
         <Text size="sm" c="dimmed">
-          {t('conversations:feedbackDescription')}
+          {t(descriptionKey)}
         </Text>
         <Stack gap="xs">
           <Text size="xs" c="dimmed" fw={500} tt="uppercase">Reasons</Text>
           <Chip.Group multiple value={reasons} onChange={setReasons}>
             <Group gap="xs">
-              {FEEDBACK_REASONS.map((reason) => (
+              {feedbackReasons.map((reason) => (
                 <Chip key={reason.value} value={reason.value} size="sm" variant="light">
                   {reason.label}
                 </Chip>
@@ -85,7 +106,7 @@ export const FeedbackDialog: FC<FeedbackDialogProps> = ({
           <Button variant="subtle" onClick={handleClose}>
             {t('conversations:cancel')}
           </Button>
-          <Button color="orange" onClick={handleSubmit}>
+          <Button color={accentColor} onClick={handleSubmit}>
             {t('conversations:submitFeedback')}
           </Button>
         </Group>

--- a/src/components/common/FeedbackInsights/FeedbackInsights.tsx
+++ b/src/components/common/FeedbackInsights/FeedbackInsights.tsx
@@ -14,7 +14,7 @@ import {
   Tooltip,
 } from '@mantine/core';
 import { LineChart } from '@mantine/charts';
-import { IconThumbDown, IconUser, IconRobot, IconChartLine } from '@tabler/icons-react';
+import { IconThumbDown, IconThumbUp, IconUser, IconRobot, IconChartLine } from '@tabler/icons-react';
 import type { FeedbackStatsResponse, RecentFeedbackEntry } from '../../../api/types';
 import { useIdentity } from '../../../contexts';
 import classes from './FeedbackInsights.module.css';
@@ -44,11 +44,19 @@ export const FeedbackInsights: FC<FeedbackInsightsProps> = ({ stats }) => {
   const [assistantMessage, setAssistantMessage] = useState<string | null>(null);
   const [selectedFeedback, setSelectedFeedback] = useState<RecentFeedbackEntry | null>(null);
   const [page, setPage] = useState<number>(1);
+  const [positivePage, setPositivePage] = useState<number>(1);
 
   const totalPages = Math.ceil(stats.recent_negative.length / PAGE_SIZE);
   const paginatedItems = useMemo(
     () => stats.recent_negative.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE),
     [stats.recent_negative, page]
+  );
+
+  const recentPositive = useMemo(() => stats.recent_positive ?? [], [stats.recent_positive]);
+  const totalPositivePages = Math.ceil(recentPositive.length / PAGE_SIZE);
+  const paginatedPositiveItems = useMemo(
+    () => recentPositive.slice((positivePage - 1) * PAGE_SIZE, positivePage * PAGE_SIZE),
+    [recentPositive, positivePage]
   );
 
   const chartData = useMemo(() => {
@@ -191,6 +199,64 @@ export const FeedbackInsights: FC<FeedbackInsightsProps> = ({ stats }) => {
             {totalPages > 1 && (
               <Group justify="center" mt="md">
                 <Pagination value={page} onChange={setPage} total={totalPages} size="sm" />
+              </Group>
+            )}
+          </div>
+        )}
+
+        {recentPositive.length > 0 && (
+          <div>
+            <Text className={classes.sectionTitle}>
+              <IconThumbUp size={16} />
+              Positive Feedbacks ({recentPositive.length})
+            </Text>
+            <Table striped highlightOnHover className={classes.table}>
+              <Table.Thead>
+                <Table.Tr>
+                  <Table.Th style={{ width: 170 }}>Date</Table.Th>
+                  <Table.Th style={{ width: 200 }}>Chat Agent</Table.Th>
+                  <Table.Th>Reasons</Table.Th>
+                  <Table.Th>Comment</Table.Th>
+                </Table.Tr>
+              </Table.Thead>
+              <Table.Tbody>
+                {paginatedPositiveItems.map((fb) => (
+                  <Table.Tr
+                    key={`${fb.message_id}-${fb.created_at}`}
+                    className={classes.clickableRow}
+                    onClick={() => {
+                      void openDrawerForFeedback(fb);
+                    }}
+                  >
+                    <Table.Td style={{ whiteSpace: 'nowrap' }}>{formatDateTime(fb.created_at)}</Table.Td>
+                    <Table.Td>
+                      <Text size="sm" lineClamp={1}>
+                        {fb.chat_agent_name ?? '—'}
+                      </Text>
+                    </Table.Td>
+                    <Table.Td>
+                      {fb.reasons.length > 0 ? (
+                        <Group gap={4} wrap="wrap">
+                          {fb.reasons.map((r) => (
+                            <Badge key={r} size="xs" variant="outline" color="teal">
+                              {r.replaceAll('_', ' ')}
+                            </Badge>
+                          ))}
+                        </Group>
+                      ) : (
+                        <Text size="xs" c="dimmed">—</Text>
+                      )}
+                    </Table.Td>
+                    <Table.Td>
+                      <Text size="sm" lineClamp={2}>{fb.comment || '—'}</Text>
+                    </Table.Td>
+                  </Table.Tr>
+                ))}
+              </Table.Tbody>
+            </Table>
+            {totalPositivePages > 1 && (
+              <Group justify="center" mt="md">
+                <Pagination value={positivePage} onChange={setPositivePage} total={totalPositivePages} size="sm" />
               </Group>
             )}
           </div>

--- a/src/components/tracing/TracingCanvasView.tsx
+++ b/src/components/tracing/TracingCanvasView.tsx
@@ -797,7 +797,7 @@ const createColumnBasedLayout = (
 
 export const TracingCanvasView: FC = () => {
   const {
-    selectedTrace,
+    combinedTrace,
     selectedNode,
     layoutDirection,
     selectNode,
@@ -838,14 +838,14 @@ export const TracingCanvasView: FC = () => {
   // Calculate layout when trace, direction, layoutVersion changes
   // NICHT bei collapsedNodes-Änderung (nur visuell filtern)
   useEffect(() => {
-    if (!selectedTrace) {
+    if (!combinedTrace) {
       setNodes([]);
       setEdges([]);
       return;
     }
 
     const { nodes: layoutNodes, edges: layoutEdges } = createColumnBasedLayout(
-      selectedTrace,
+      combinedTrace,
       layoutDirection,
       selectedNode?.id || null,
       (nodeId) => selectNode(nodeId),
@@ -880,7 +880,7 @@ export const TracingCanvasView: FC = () => {
 
     setNodes(layoutNodes);
     setEdges(highlightedEdges);
-  }, [selectedTrace, layoutDirection, selectedNode, selectNode, setNodes, setEdges, collapsedNodes, handleToggleCollapse, layoutVersion, selectedEdgeId]);
+  }, [combinedTrace, layoutDirection, selectedNode, selectNode, setNodes, setEdges, collapsedNodes, handleToggleCollapse, layoutVersion, selectedEdgeId]);
 
   // Fit view on load
   const onInit = useCallback((instance: ReactFlowInstance) => {
@@ -924,7 +924,7 @@ export const TracingCanvasView: FC = () => {
     }
   }, []);
 
-  if (!selectedTrace) {
+  if (!combinedTrace) {
     return (
       <div className={classes.emptyContainer}>
         <p>Kein Trace ausgewählt</p>

--- a/src/components/tracing/TracingContext.tsx
+++ b/src/components/tracing/TracingContext.tsx
@@ -29,6 +29,13 @@ interface TracingContextState {
   // Data
   traces: FullTraceResponse[];
   selectedTrace: FullTraceResponse | null;
+  /**
+   * All traces of the conversation merged into a single logical trace whose
+   * root nodes are the concatenation of every trace's root nodes ordered by
+   * creation time. Used by the canvas so multiple N8N executions render as one
+   * continuous conversation flow (like Foundry).
+   */
+  combinedTrace: FullTraceResponse | null;
   selectedNode: TraceNodeResponse | null;
 
   // UI State
@@ -80,6 +87,46 @@ const findNodeById = (
     }
   }
   return null;
+};
+
+// ============================================================================
+// Helper: Find node + owning trace across ALL traces
+// ============================================================================
+
+const findNodeAndTrace = (
+  traces: FullTraceResponse[],
+  nodeId: string
+): { trace: FullTraceResponse; node: TraceNodeResponse } | null => {
+  for (const trace of traces) {
+    const node = findNodeById(trace.nodes, nodeId);
+    if (node) {
+      return { trace, node };
+    }
+  }
+  return null;
+};
+
+// ============================================================================
+// Helper: Build a single combined trace from all conversation traces
+// ============================================================================
+
+const buildCombinedTrace = (
+  traces: FullTraceResponse[]
+): FullTraceResponse | null => {
+  if (traces.length === 0) return null;
+  if (traces.length === 1) return traces[0];
+
+  const ordered = [...traces].sort(
+    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+  );
+
+  const combinedNodes: TraceNodeResponse[] = ordered.flatMap((t) => t.nodes);
+
+  return {
+    ...ordered[0],
+    id: `combined-${ordered[0].id}`,
+    nodes: combinedNodes,
+  };
 };
 
 // ============================================================================
@@ -160,6 +207,9 @@ export const TracingProvider: FC<TracingProviderProps> = ({
   // Callback for centering on node (will be connected to canvas)
   const [, setCenterNodeId] = useState<string | null>(null);
 
+  // Combined trace: all conversation traces merged into one continuous flow
+  const combinedTrace = useMemo(() => buildCombinedTrace(traces), [traces]);
+
   // Effect: Sync selectedTrace when traces prop changes (e.g. after refresh)
   // This is needed because useState only uses initialTrace on first mount
   useEffect(() => {
@@ -220,14 +270,14 @@ export const TracingProvider: FC<TracingProviderProps> = ({
         setSelectedNode(null);
         return;
       }
-      if (!selectedTrace) return;
 
-      const node = findNodeById(selectedTrace.nodes, nodeId);
-      if (node) {
-        setSelectedNode(node);
+      const result = findNodeAndTrace(traces, nodeId);
+      if (result) {
+        setSelectedTrace(result.trace);
+        setSelectedNode(result.node);
       }
     },
-    [selectedTrace]
+    [traces]
   );
 
   const toggleHierarchyCollapse = useCallback((nodeId: string) => {
@@ -314,6 +364,7 @@ export const TracingProvider: FC<TracingProviderProps> = ({
     () => ({
       traces,
       selectedTrace,
+      combinedTrace,
       selectedNode,
       layoutDirection,
       hierarchyCollapsed,
@@ -335,6 +386,7 @@ export const TracingProvider: FC<TracingProviderProps> = ({
     [
       traces,
       selectedTrace,
+      combinedTrace,
       selectedNode,
       layoutDirection,
       hierarchyCollapsed,

--- a/src/components/tracing/TracingHierarchyView.module.css
+++ b/src/components/tracing/TracingHierarchyView.module.css
@@ -69,6 +69,12 @@
   flex-shrink: 0;
 }
 
+.headerActions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
 .fullscreenButton {
   opacity: 0.7;
 }

--- a/src/components/tracing/TracingHierarchyView.tsx
+++ b/src/components/tracing/TracingHierarchyView.tsx
@@ -7,6 +7,7 @@ import {
   IconChevronDown,
   IconChevronRight,
   IconMaximize,
+  IconRefresh,
   IconCheck,
   IconX,
   IconLoader2,
@@ -324,6 +325,141 @@ const TraceRootItem: FC<TraceRootItemProps> = ({
 };
 
 // ============================================================================
+// CONVERSATION GROUP (multiple traces = one logical conversation)
+// ============================================================================
+
+const CONVERSATION_GROUP_KEY = 'conversation-group-root';
+
+interface ConversationGroupProps {
+  traces: FullTraceResponse[];
+  selectedTraceId: string | null;
+  selectedNodeId: string | null;
+  collapsedKeys: Set<string>;
+  onToggleGroup: (key: string) => void;
+  onSelectTrace: (traceId: string) => void;
+}
+
+const ConversationGroup: FC<ConversationGroupProps> = ({
+  traces,
+  selectedTraceId,
+  selectedNodeId,
+  collapsedKeys,
+  onToggleGroup,
+  onSelectTrace,
+}) => {
+  const groupExpanded = !collapsedKeys.has(CONVERSATION_GROUP_KEY);
+  const totalNodes = traces.reduce((sum, t) => sum + (t.nodes?.length ?? 0), 0);
+
+  return (
+    <>
+      <UnstyledButton
+        className={`${classes.treeItem} ${classes.traceRoot}`}
+        onClick={() => onToggleGroup(CONVERSATION_GROUP_KEY)}
+      >
+        <span className={classes.expandIcon}>
+          {groupExpanded ? <IconChevronDown size={14} /> : <IconChevronRight size={14} />}
+        </span>
+        <Badge size="xs" variant="light" color={getTypeBadgeColor('conversation')} className={classes.typeBadge}>
+          conversation
+        </Badge>
+        <DelayedTooltip label="Conversation">
+          <Text size="xs" className={classes.nodeName}>
+            Conversation
+          </Text>
+        </DelayedTooltip>
+        <Badge size="xs" variant="light" color="gray" className={classes.typeBadge}>
+          {traces.length}
+        </Badge>
+        <span className={classes.statusIcon}>
+          {getStatusIcon(totalNodes > 0 ? 'completed' : 'pending')}
+        </span>
+      </UnstyledButton>
+
+      {groupExpanded && (
+        <div className={classes.childrenContainer}>
+          <div className={classes.treeLine} style={{ left: '15px' }} />
+          {traces.map((trace, index) => {
+            const traceRootKey = `trace-root-${trace.id}`;
+            const isExpanded = !collapsedKeys.has(traceRootKey);
+            const isRootSelected = selectedTraceId === trace.id && selectedNodeId === null;
+
+            return (
+              <ExecutionSubGroup
+                key={trace.id}
+                trace={trace}
+                index={index}
+                isSelected={isRootSelected}
+                isExpanded={isExpanded}
+                onSelect={() => onSelectTrace(trace.id)}
+                onToggle={() => onToggleGroup(traceRootKey)}
+              />
+            );
+          })}
+        </div>
+      )}
+    </>
+  );
+};
+
+interface ExecutionSubGroupProps {
+  trace: FullTraceResponse;
+  index: number;
+  isSelected: boolean;
+  isExpanded: boolean;
+  onSelect: () => void;
+  onToggle: () => void;
+}
+
+const ExecutionSubGroup: FC<ExecutionSubGroupProps> = ({
+  trace,
+  index,
+  isSelected,
+  isExpanded,
+  onSelect,
+  onToggle,
+}) => {
+  const hasNodes = trace.nodes && trace.nodes.length > 0;
+  const label = `Message ${index + 1}`;
+
+  return (
+    <>
+      <UnstyledButton
+        className={`${classes.treeItem} ${isSelected ? classes.treeItemSelected : ''}`}
+        onClick={onSelect}
+      >
+        {hasNodes ? (
+          <span className={classes.expandIcon} onClick={(e) => { e.stopPropagation(); onToggle(); }}>
+            {isExpanded ? <IconChevronDown size={14} /> : <IconChevronRight size={14} />}
+          </span>
+        ) : (
+          <span className={classes.expandIconPlaceholder} />
+        )}
+        <Badge size="xs" variant="light" color={getTypeBadgeColor(trace.contextType || '')} className={classes.typeBadge}>
+          {trace.contextType === 'workflow' ? 'agent' : trace.contextType}
+        </Badge>
+        <DelayedTooltip label={trace.referenceName || label}>
+          <Text size="xs" className={classes.nodeName}>
+            {label}
+          </Text>
+        </DelayedTooltip>
+        <span className={classes.statusIcon}>
+          {getStatusIcon(trace.nodes?.[0]?.status || 'completed')}
+        </span>
+      </UnstyledButton>
+
+      {hasNodes && isExpanded && (
+        <div className={classes.childrenContainer}>
+          <div className={classes.treeLine} style={{ left: '15px' }} />
+          {trace.nodes.map((node) => (
+            <TreeItemWrapper key={node.id} node={node} depth={2} />
+          ))}
+        </div>
+      )}
+    </>
+  );
+};
+
+// ============================================================================
 // MAIN COMPONENT
 // ============================================================================
 
@@ -338,6 +474,8 @@ interface TracingHierarchyViewProps {
   showDataPanels?: boolean;
   /** Callback for fullscreen button */
   onOpenFullscreen?: () => void;
+  /** Callback to refresh traces */
+  onRefresh?: () => void | Promise<void>;
 }
 
 export const TracingHierarchyView: FC<TracingHierarchyViewProps> = ({
@@ -346,6 +484,7 @@ export const TracingHierarchyView: FC<TracingHierarchyViewProps> = ({
   showHeader = true,
   showDataPanels = false,
   onOpenFullscreen,
+  onRefresh,
 }) => {
   const {
     traces,
@@ -360,6 +499,26 @@ export const TracingHierarchyView: FC<TracingHierarchyViewProps> = ({
   const { t } = useTranslation();
   const containerRef = useRef<HTMLDivElement>(null);
   const [dataPanelsHeight, setDataPanelsHeight] = useState(DEFAULT_PANELS_HEIGHT);
+
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const handleRefresh = useCallback(async () => {
+    if (!onRefresh || isRefreshing) return;
+    setIsRefreshing(true);
+    try {
+      await onRefresh();
+    } finally {
+      setIsRefreshing(false);
+    }
+  }, [onRefresh, isRefreshing]);
+
+  const orderedTraces = useMemo(
+    () =>
+      [...traces].sort(
+        (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+      ),
+    [traces]
+  );
 
   const handlePanelsResize = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -409,18 +568,33 @@ export const TracingHierarchyView: FC<TracingHierarchyViewProps> = ({
       {showHeader && (
         <div className={classes.header}>
           <Text size="sm" fw={600}>Tracing Hierarchie</Text>
-          {onOpenFullscreen && (
-            <Tooltip label="Vollbild">
-              <ActionIcon
-                variant="subtle"
-                size="sm"
-                onClick={onOpenFullscreen}
-                className={classes.fullscreenButton}
-              >
-                <IconMaximize size={16} />
-              </ActionIcon>
-            </Tooltip>
-          )}
+          <div className={classes.headerActions}>
+            {onRefresh && (
+              <Tooltip label="Traces aktualisieren">
+                <ActionIcon
+                  variant="subtle"
+                  size="sm"
+                  onClick={handleRefresh}
+                  loading={isRefreshing}
+                  className={classes.fullscreenButton}
+                >
+                  <IconRefresh size={16} />
+                </ActionIcon>
+              </Tooltip>
+            )}
+            {onOpenFullscreen && (
+              <Tooltip label="Vollbild">
+                <ActionIcon
+                  variant="subtle"
+                  size="sm"
+                  onClick={onOpenFullscreen}
+                  className={classes.fullscreenButton}
+                >
+                  <IconMaximize size={16} />
+                </ActionIcon>
+              </Tooltip>
+            )}
+          </div>
         </div>
       )}
 
@@ -430,25 +604,39 @@ export const TracingHierarchyView: FC<TracingHierarchyViewProps> = ({
         style={showDataPanels ? { flex: 1, minHeight: TREE_MIN_HEIGHT } : undefined}
       >
         <div className={classes.treeContainer}>
-          {traces.map((trace) => {
-            const isRootSelected = selectedTrace?.id === trace.id && selectedNode === null;
-            const traceRootKey = `trace-root-${trace.id}`;
-            const isExpanded = !hierarchyCollapsed.has(traceRootKey);
+          {orderedTraces.length > 1 ? (
+            <ConversationGroup
+              traces={orderedTraces}
+              selectedTraceId={selectedTrace?.id ?? null}
+              selectedNodeId={selectedNode?.id ?? null}
+              collapsedKeys={hierarchyCollapsed}
+              onToggleGroup={toggleHierarchyCollapse}
+              onSelectTrace={(traceId) => {
+                selectTrace(traceId);
+                selectNode(null);
+              }}
+            />
+          ) : (
+            orderedTraces.map((trace) => {
+              const isRootSelected = selectedTrace?.id === trace.id && selectedNode === null;
+              const traceRootKey = `trace-root-${trace.id}`;
+              const isExpanded = !hierarchyCollapsed.has(traceRootKey);
 
-            return (
-              <TraceRootItem
-                key={trace.id}
-                trace={trace}
-                isSelected={isRootSelected}
-                isExpanded={isExpanded}
-                onSelect={() => {
-                  selectTrace(trace.id);
-                  selectNode(null);
-                }}
-                onToggle={() => toggleHierarchyCollapse(traceRootKey)}
-              />
-            );
-          })}
+              return (
+                <TraceRootItem
+                  key={trace.id}
+                  trace={trace}
+                  isSelected={isRootSelected}
+                  isExpanded={isExpanded}
+                  onSelect={() => {
+                    selectTrace(trace.id);
+                    selectNode(null);
+                  }}
+                  onToggle={() => toggleHierarchyCollapse(traceRootKey)}
+                />
+              );
+            })
+          )}
         </div>
       </ScrollArea>
 

--- a/src/components/tracing/TracingSidebar.tsx
+++ b/src/components/tracing/TracingSidebar.tsx
@@ -20,13 +20,15 @@ import classes from './TracingSidebar.module.css';
 interface TracingSidebarProps {
   /** Callback when fullscreen button is clicked */
   onOpenFullscreen?: () => void;
+  /** Callback to refresh traces */
+  onRefresh?: () => void | Promise<void>;
 }
 
 // ============================================================================
 // MAIN COMPONENT
 // ============================================================================
 
-export const TracingSidebar: FC<TracingSidebarProps> = ({ onOpenFullscreen }) => {
+export const TracingSidebar: FC<TracingSidebarProps> = ({ onOpenFullscreen, onRefresh }) => {
   return (
     <div className={classes.container}>
       <TracingHierarchyView
@@ -35,6 +37,7 @@ export const TracingSidebar: FC<TracingSidebarProps> = ({ onOpenFullscreen }) =>
         showHeader={true}
         showDataPanels={true}
         onOpenFullscreen={onOpenFullscreen}
+        onRefresh={onRefresh}
       />
     </div>
   );

--- a/src/components/tracing/TracingVisualDialog.tsx
+++ b/src/components/tracing/TracingVisualDialog.tsx
@@ -23,6 +23,7 @@ interface TracingVisualDialogProps {
   onClose: () => void;
   traces: FullTraceResponse[];
   initialTraceId?: string;
+  onRefresh?: () => void | Promise<void>;
 }
 
 // ============================================================================
@@ -31,9 +32,10 @@ interface TracingVisualDialogProps {
 
 interface DialogContentProps {
   onClose: () => void;
+  onRefresh?: () => void | Promise<void>;
 }
 
-const DialogContent: FC<DialogContentProps> = ({ onClose }) => {
+const DialogContent: FC<DialogContentProps> = ({ onClose, onRefresh }) => {
   const { selectedTrace, hierarchyVisible, chatVisible } = useTracing();
 
   // Panel sizes (percentages)
@@ -190,7 +192,7 @@ const DialogContent: FC<DialogContentProps> = ({ onClose }) => {
             className={classes.hierarchyContainer}
             style={{ width: `${hierarchyWidth}%` }}
           >
-            <TracingHierarchyView />
+            <TracingHierarchyView onRefresh={onRefresh} />
           </Box>
         )}
 
@@ -225,6 +227,7 @@ export const TracingVisualDialog: FC<TracingVisualDialogProps> = ({
   onClose,
   traces,
   initialTraceId,
+  onRefresh,
 }) => {
   // Prevent body scroll when modal is open
   useEffect(() => {
@@ -283,7 +286,7 @@ export const TracingVisualDialog: FC<TracingVisualDialogProps> = ({
       }}
     >
       <TracingProvider traces={traces} initialTraceId={initialTraceId}>
-        <DialogContent onClose={onClose} />
+        <DialogContent onClose={onClose} onRefresh={onRefresh} />
       </TracingProvider>
     </Modal>
   );

--- a/src/contexts/IdentityContext.tsx
+++ b/src/contexts/IdentityContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useEffect, useRef, useState } from 'react';
-import type { ReactNode, FC } from 'react';
+import type { ReactNode, FC, MouseEvent as ReactMouseEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../auth';
 import { UnifiedUIAPIClient } from '../api/client';
@@ -30,8 +30,10 @@ const IdentityContext = createContext<IdentityContextType | undefined>(undefined
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
 const AGENT_SERVICE_URL = import.meta.env.VITE_AGENT_SERVICE_URL || 'http://localhost:8085';
 
-function createToastClickHandler(action: () => void): (event: MouseEvent) => void {
-  return (event: MouseEvent) => {
+function createToastClickHandler(
+  action: () => void
+): (event: ReactMouseEvent<HTMLDivElement>) => void {
+  return (event: ReactMouseEvent<HTMLDivElement>) => {
     const target = event.target;
     if (target instanceof Element && target.closest('.mantine-Notification-closeButton')) {
       return;

--- a/src/contexts/IdentityContext.tsx
+++ b/src/contexts/IdentityContext.tsx
@@ -30,6 +30,16 @@ const IdentityContext = createContext<IdentityContextType | undefined>(undefined
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
 const AGENT_SERVICE_URL = import.meta.env.VITE_AGENT_SERVICE_URL || 'http://localhost:8085';
 
+function createToastClickHandler(action: () => void): (event: MouseEvent) => void {
+  return (event: MouseEvent) => {
+    const target = event.target;
+    if (target instanceof Element && target.closest('.mantine-Notification-closeButton')) {
+      return;
+    }
+    action();
+  };
+}
+
 interface IdentityProviderProps {
   children: ReactNode;
 }
@@ -63,7 +73,7 @@ const IdentityProviderInner: FC<IdentityProviderProps> = ({ children }) => {
             const message = error.requiredRoles.length > 0
               ? `${t('accessDenied.requiredRoles')}: ${error.requiredRoles.join(', ')}`
               : t('permissionDenied');
-            notifications.show({ title, message, color: 'orange', position: 'top-right', onClick: () => openDrawerRef.current() });
+            notifications.show({ title, message, color: 'orange', position: 'top-right', onClick: createToastClickHandler(() => openDrawerRef.current()) });
             addNotificationRef.current({ title, message, color: 'orange' });
             return;
           }
@@ -71,7 +81,7 @@ const IdentityProviderInner: FC<IdentityProviderProps> = ({ children }) => {
           if (error instanceof ApiError) {
             const title = error.status > 0 ? `${error.status} ${error.statusText}` : error.statusText;
             const message = error.detail || t('unexpectedError');
-            notifications.show({ title, message, color: 'red', position: 'top-right', onClick: () => openDrawerRef.current() });
+            notifications.show({ title, message, color: 'red', position: 'top-right', onClick: createToastClickHandler(() => openDrawerRef.current()) });
             addNotificationRef.current({
               title,
               message,
@@ -85,12 +95,12 @@ const IdentityProviderInner: FC<IdentityProviderProps> = ({ children }) => {
           }
           const title = t('error');
           const message = error.message || t('unexpectedError');
-          notifications.show({ title, message, color: 'red', position: 'top-right', onClick: () => openDrawerRef.current() });
+          notifications.show({ title, message, color: 'red', position: 'top-right', onClick: createToastClickHandler(() => openDrawerRef.current()) });
           addNotificationRef.current({ title, message, color: 'red' });
         },
         onSuccess: (message) => {
           const title = t('success');
-          notifications.show({ title, message, color: 'green', position: 'top-right', onClick: () => openDrawerRef.current() });
+          notifications.show({ title, message, color: 'green', position: 'top-right', onClick: createToastClickHandler(() => openDrawerRef.current()) });
           addNotificationRef.current({ title, message, color: 'green' });
         },
       });

--- a/src/hooks/chat/useChat.ts
+++ b/src/hooks/chat/useChat.ts
@@ -394,9 +394,7 @@ export function useChat({
           }).concat(completedMessage);
         });
 
-        setTimeout(() => {
-          onRefreshTraces();
-        }, 1500);
+        void onRefreshTraces();
       },
       (title: string) => {
         if (!activeConversationId) return;

--- a/src/hooks/conversation/useConversationTracing.ts
+++ b/src/hooks/conversation/useConversationTracing.ts
@@ -19,6 +19,7 @@ interface UseConversationTracingReturn {
   handleNodeReferenceIdChange: (referenceId: string | null) => void;
   setMessagesRef: (messages: MessageResponse[]) => void;
   refreshTraces: () => Promise<void>;
+  refreshTracesWithRetry: () => Promise<void>;
   handleToggleTracingSidebar: () => void;
   handleViewTrace: (extMessageId: string) => Promise<void>;
   handleOpenTracingFullscreen: () => void;
@@ -42,6 +43,9 @@ export function useConversationTracing({
     messagesRef.current = messages;
   }, []);
 
+  const tracesRef = useRef<FullTraceResponse[]>([]);
+  tracesRef.current = traces;
+
   const refreshTraces = useCallback(async () => {
     if (!apiClient || !tenantId || !conversationId) return;
     try {
@@ -49,6 +53,28 @@ export function useConversationTracing({
       setTraces(tracesData.traces || []);
     } catch (error) {
       console.error('Failed to refresh traces:', error);
+    }
+  }, [apiClient, tenantId, conversationId]);
+
+  const refreshTracesWithRetry = useCallback(async () => {
+    if (!apiClient || !tenantId || !conversationId) return;
+
+    const RETRY_ATTEMPTS = 8;
+    const RETRY_DELAY_MS = 1500;
+    const previousCount = tracesRef.current.length;
+
+    for (let attempt = 0; attempt < RETRY_ATTEMPTS; attempt++) {
+      try {
+        const tracesData = await apiClient.getConversationTraces(tenantId, conversationId);
+        const nextTraces = tracesData.traces || [];
+        setTraces(nextTraces);
+        if (nextTraces.length > previousCount) {
+          return;
+        }
+      } catch (error) {
+        console.error('Failed to refresh traces (retry):', error);
+      }
+      await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
     }
   }, [apiClient, tenantId, conversationId]);
 
@@ -174,6 +200,7 @@ export function useConversationTracing({
     handleNodeReferenceIdChange,
     setMessagesRef,
     refreshTraces,
+    refreshTracesWithRetry,
     handleToggleTracingSidebar,
     handleViewTrace,
     handleOpenTracingFullscreen,

--- a/src/i18n/locales/de-DE/conversations.json
+++ b/src/i18n/locales/de-DE/conversations.json
@@ -73,6 +73,8 @@
   "older": "Älter",
   "feedbackTitle": "Was war falsch?",
   "feedbackDescription": "Helfen Sie uns, indem Sie beschreiben, was an dieser Antwort falsch war.",
+  "feedbackTitlePositive": "Was war gut?",
+  "feedbackDescriptionPositive": "Helfen Sie uns, indem Sie beschreiben, was an dieser Antwort hilfreich war.",
   "feedbackPlaceholder": "Beschreiben Sie, was nicht hilfreich oder falsch war...",
   "submitFeedback": "Feedback absenden",
   "selectChatAgent": "Chat-Agent auswählen",

--- a/src/i18n/locales/en-US/conversations.json
+++ b/src/i18n/locales/en-US/conversations.json
@@ -73,6 +73,8 @@
   "older": "Older",
   "feedbackTitle": "What went wrong?",
   "feedbackDescription": "Help us improve by describing what was wrong with this response.",
+  "feedbackTitlePositive": "What went well?",
+  "feedbackDescriptionPositive": "Help us improve by describing what was helpful about this response.",
   "feedbackPlaceholder": "Describe what was not helpful or incorrect...",
   "submitFeedback": "Submit Feedback",
   "selectChatAgent": "Select Chat Agent",

--- a/src/pages/ConversationsPage/ConversationsPage.tsx
+++ b/src/pages/ConversationsPage/ConversationsPage.tsx
@@ -71,7 +71,7 @@ export const ConversationsPage: FC = () => {
     setCurrentConversation: convList.setCurrentConversation,
     setConversations: convList.setConversations,
     setSelectedChatAgentId: convList.setSelectedChatAgentId,
-    onRefreshTraces: tracing.refreshTraces,
+    onRefreshTraces: tracing.refreshTracesWithRetry,
     onMessageSent: handleTrackChatAgent,
   });
 
@@ -219,7 +219,10 @@ export const ConversationsPage: FC = () => {
       initialNodeReferenceId={tracing.selectedNodeReferenceId}
       onNodeReferenceIdChange={tracing.handleNodeReferenceIdChange}
     >
-      <TracingSidebar onOpenFullscreen={tracing.handleOpenTracingFullscreen} />
+      <TracingSidebar
+        onOpenFullscreen={tracing.handleOpenTracingFullscreen}
+        onRefresh={tracing.refreshTraces}
+      />
     </TracingProvider>
   ) : undefined;
 
@@ -420,6 +423,7 @@ export const ConversationsPage: FC = () => {
           opened={tracing.tracingDialogOpen}
           onClose={() => tracing.setTracingDialogOpen(false)}
           traces={tracing.traces}
+          onRefresh={tracing.refreshTraces}
         />
       )}
     </MainLayout>

--- a/src/pages/EmbedChatPage/EmbedChatPage.tsx
+++ b/src/pages/EmbedChatPage/EmbedChatPage.tsx
@@ -109,7 +109,7 @@ export const EmbedChatPage: FC = () => {
     setCurrentConversation,
     setConversations,
     setSelectedChatAgentId,
-    onRefreshTraces: tracing.refreshTraces,
+    onRefreshTraces: tracing.refreshTracesWithRetry,
     onNavigate: handleNavigate,
   });
 
@@ -203,7 +203,10 @@ export const EmbedChatPage: FC = () => {
       initialNodeReferenceId={tracing.selectedNodeReferenceId}
       onNodeReferenceIdChange={tracing.handleNodeReferenceIdChange}
     >
-      <TracingSidebar onOpenFullscreen={tracing.handleOpenTracingFullscreen} />
+      <TracingSidebar
+        onOpenFullscreen={tracing.handleOpenTracingFullscreen}
+        onRefresh={tracing.refreshTraces}
+      />
     </TracingProvider>
   ) : undefined;
 
@@ -268,6 +271,7 @@ export const EmbedChatPage: FC = () => {
           opened={tracing.tracingDialogOpen}
           onClose={() => tracing.setTracingDialogOpen(false)}
           traces={tracing.traces}
+          onRefresh={tracing.refreshTraces}
         />
       )}
     </Box>

--- a/src/test/__tests__/tracingContext.test.tsx
+++ b/src/test/__tests__/tracingContext.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { TracingProvider, useTracing } from '../../components/tracing/TracingContext';
+import type { FullTraceResponse } from '../../api/types';
+
+beforeAll(() => {
+  if (typeof window.localStorage?.getItem !== 'function') {
+    const store = new Map<string, string>();
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+        setItem: (key: string, value: string) => { store.set(key, String(value)); },
+        removeItem: (key: string) => { store.delete(key); },
+        clear: () => { store.clear(); },
+        key: (index: number) => Array.from(store.keys())[index] ?? null,
+        get length() { return store.size; },
+      },
+    });
+  }
+});
+
+const makeTrace = (
+  id: string,
+  createdAt: string,
+  nodeIds: string[]
+): FullTraceResponse => ({
+  id,
+  tenantId: 'tenant-1',
+  contextType: 'conversation',
+  referenceId: id,
+  referenceName: 'N8N Workflow Execution',
+  conversationId: 'conv-1',
+  nodes: nodeIds.map((nid) => ({
+    id: nid,
+    name: nid,
+    type: 'workflow',
+    status: 'completed',
+  })),
+  createdAt,
+  updatedAt: createdAt,
+});
+
+const wrapperFor = (traces: FullTraceResponse[]) =>
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <TracingProvider traces={traces}>{children}</TracingProvider>;
+  };
+
+describe('TracingContext', () => {
+  it('returns the single trace as combinedTrace when only one trace exists', () => {
+    const traces = [makeTrace('t1', '2026-01-01T00:00:00Z', ['a', 'b'])];
+    const { result } = renderHook(() => useTracing(), { wrapper: wrapperFor(traces) });
+
+    expect(result.current.combinedTrace?.id).toBe('t1');
+    expect(result.current.combinedTrace?.nodes.map((n) => n.id)).toEqual(['a', 'b']);
+  });
+
+  it('merges multiple traces into one combinedTrace ordered by createdAt', () => {
+    const traces = [
+      makeTrace('t2', '2026-01-02T00:00:00Z', ['c', 'd']),
+      makeTrace('t1', '2026-01-01T00:00:00Z', ['a', 'b']),
+    ];
+    const { result } = renderHook(() => useTracing(), { wrapper: wrapperFor(traces) });
+
+    expect(result.current.combinedTrace?.nodes.map((n) => n.id)).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('selectNode finds a node in a non-default trace and switches selectedTrace', () => {
+    const traces = [
+      makeTrace('t1', '2026-01-01T00:00:00Z', ['a', 'b']),
+      makeTrace('t2', '2026-01-02T00:00:00Z', ['c', 'd']),
+    ];
+    const { result } = renderHook(() => useTracing(), { wrapper: wrapperFor(traces) });
+
+    act(() => {
+      result.current.selectNode('d');
+    });
+
+    expect(result.current.selectedNode?.id).toBe('d');
+    expect(result.current.selectedTrace?.id).toBe('t2');
+  });
+
+  it('selectNode(null) clears the selection', () => {
+    const traces = [makeTrace('t1', '2026-01-01T00:00:00Z', ['a'])];
+    const { result } = renderHook(() => useTracing(), { wrapper: wrapperFor(traces) });
+
+    act(() => {
+      result.current.selectNode('a');
+    });
+    expect(result.current.selectedNode?.id).toBe('a');
+
+    act(() => {
+      result.current.selectNode(null);
+    });
+    expect(result.current.selectedNode).toBeNull();
+  });
+});


### PR DESCRIPTION
…N tracing

- Notification toast: clicking the X (close) no longer opens the notification panel; only a body click does.
- Feedback: thumbs-up now opens a comment dialog (like thumbs-down) and positive feedbacks with reasons/comments are shown in admin analytics.
- N8N tracing: merge multiple conversation traces into one continuous flow in the canvas (combinedTrace), group them under a single conversation root in the hierarchy, and allow selecting nodes across all traces.
- Tracing: refresh traces via retry-polling after a message completes (fixes the off-by-one lag with async N8N imports) and add a refresh icon button to the tracing hierarchy header (chat sidebar + fullscreen).