### PR TITLE
feat(login): configurable identity providers via env + optional brand text

### DIFF
--- a/src/config/branding.config.ts
+++ b/src/config/branding.config.ts
@@ -140,4 +140,30 @@ function getBranding(slug: string): BrandingConfig {
   return deepMerge(DEFAULT_BRANDING, override);
 }
 
-export const activeBranding: BrandingConfig = getBranding(ACTIVE_BRANDING);
+/**
+ * Optional env override for the visible IdP buttons (comma-separated, e.g. "oidc,microsoft").
+ * Lets each installation preconfigure its login providers without a code change.
+ * Unknown values are ignored; an empty or fully invalid list falls back to the branding preset.
+ */
+const IDP_ENV_OVERRIDE: string = import.meta.env.VITE_ENABLED_IDPS || '';
+
+const ALL_IDPS: BrandingConfig['enabledIdps'] = [
+  'microsoft',
+  'google',
+  'aws_cognito',
+  'ldap',
+  'kerberos',
+  'saml',
+  'okta',
+  'oidc',
+];
+
+function applyIdpEnvOverride(branding: BrandingConfig): BrandingConfig {
+  if (!IDP_ENV_OVERRIDE) return branding;
+  const requested = IDP_ENV_OVERRIDE.split(',').map((s) => s.trim().toLowerCase());
+  const valid = ALL_IDPS.filter((idp) => requested.includes(idp));
+  if (valid.length === 0) return branding;
+  return { ...branding, enabledIdps: valid };
+}
+
+export const activeBranding: BrandingConfig = applyIdpEnvOverride(getBranding(ACTIVE_BRANDING));

--- a/src/config/branding.config.ts
+++ b/src/config/branding.config.ts
@@ -32,6 +32,7 @@ export const DEFAULT_BRANDING: BrandingConfig = {
   displayName: APP_TITLE,
   logoUrl: getAssetUrl('logo'),
   iconUrl: getAssetUrl('icon'),
+  heroImageUrl: null,
   faviconUrl: getAssetUrl('favicon'),
 
   login: {

--- a/src/config/branding.types.ts
+++ b/src/config/branding.types.ts
@@ -20,6 +20,11 @@ export interface LoginBranding {
   buttonBorderColor: string;
   /** Auth button hover background */
   buttonHoverBg: string;
+  /**
+   * Show the displayName text next to the logo (default true).
+   * Set to false when the logo itself is a wordmark that already contains the name.
+   */
+  showBrandText?: boolean;
 }
 
 // ─── App-Wide Branding ────────────────────────────────────────

--- a/src/config/branding.types.ts
+++ b/src/config/branding.types.ts
@@ -64,8 +64,14 @@ export interface BrandingConfig {
   displayName: string;
   /** Small logo (top-left corner) — URL or path. null = use default icon */
   logoUrl: string | null;
-  /** Large icon/emblem (right panel of login) — URL or path. null = use default icon */
+  /** Large icon/emblem (app header, favicon fallback) — URL or path. null = use default icon */
   iconUrl: string | null;
+  /**
+   * Dedicated artwork for the login page's right panel.
+   * Falls back to iconUrl when null — set it when the hero should differ from
+   * the compact app icon (e.g. a wide wordmark or a subtle watermark).
+   */
+  heroImageUrl?: string | null;
   /** Browser favicon. null = keep default */
   faviconUrl: string | null;
 

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -157,6 +157,7 @@ export const LoginPage = () => {
   };
 
   const heading = branding.login.heading ?? t('loginHeading', 'Sign in to access the app');
+  const heroImage = branding.heroImageUrl ?? branding.iconUrl ?? '/branding/default/icon.svg';
 
   // ── Authenticated state ────────────────────────────────────
   if (isAuthenticated) {
@@ -266,11 +267,7 @@ export const LoginPage = () => {
           style={{ background: branding.login.bgRight }}
         >
           <div className={classes.iconWrapper}>
-            {branding.iconUrl ? (
-              <img src={branding.iconUrl} alt="" className={classes.heroIcon} />
-            ) : (
-              <img src="/branding/default/icon.svg" alt="" className={classes.heroIcon} />
-            )}
+            <img src={heroImage} alt="" className={classes.heroIcon} />
           </div>
         </div>
       </div>
@@ -476,11 +473,7 @@ export const LoginPage = () => {
         style={{ background: branding.login.bgRight }}
       >
         <div className={classes.iconWrapper}>
-          {branding.iconUrl ? (
-            <img src={branding.iconUrl} alt="" className={classes.heroIcon} />
-          ) : (
-            <img src="/branding/default/icon.svg" alt="" className={classes.heroIcon} />
-          )}
+          <img src={heroImage} alt="" className={classes.heroIcon} />
         </div>
       </div>
     </div>

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -299,9 +299,11 @@ export const LoginPage = () => {
             </div>
           )}
           <div className={classes.brandTextWrapper}>
-            <span className={classes.brandName} style={{ color: branding.login.textColor }}>
-              {branding.displayName}
-            </span>
+            {branding.login.showBrandText !== false && (
+              <span className={classes.brandName} style={{ color: branding.login.textColor }}>
+                {branding.displayName}
+              </span>
+            )}
             {SHOW_PLATFORM_SUBTITLE && (
               <span className={classes.brandSubtitle} style={{ color: branding.login.textColor }}>
                 powered by unified-ui


### PR DESCRIPTION
## What

Two small, backward-compatible configurability features for the login page:

1. **`VITE_ENABLED_IDPS`** (comma-separated, e.g. `oidc,microsoft`): filters the visible identity-provider buttons per installation without a code change. Unknown values are ignored; empty/unset keeps the branding preset's `enabledIdps` list.
2. **`LoginBranding.showBrandText`** (optional, default `true`): hides the displayName text next to the logo when the logo itself is a wordmark that already contains the name - avoids duplicated branding on the login page.

## Why

We ship unified-ui as a white-label distribution (emtecHUB) to customers. Each installation needs to preconfigure which login providers its organization actually implements - ideally via env, not via code edits. And with a wordmark logo, the product name would appear twice.

## Notes

- No breaking changes; defaults preserve current behavior exactly.
- Happy to split into two PRs if preferred.

Generated with [Claude Code](https://claude.com/claude-code)