### PR TITLE
fix(theme): make VITE_THEME_PRESET reach the CSS modules

### DIFF
--- a/src/components/chat/ChatContent/ChatContent.module.css
+++ b/src/components/chat/ChatContent/ChatContent.module.css
@@ -59,7 +59,7 @@
 }
 
 [data-mantine-color-scheme="dark"] .messageWrapper.highlighted {
-  background-color: rgba(33, 150, 243, 0.1);
+  background-color: rgba(var(--color-primary-rgb), 0.1);
 }
 
 /* Flash animation for newly highlighted message */
@@ -74,10 +74,10 @@
 
 @keyframes highlightFlashDark {
   0% {
-    background-color: rgba(33, 150, 243, 0.3);
+    background-color: rgba(var(--color-primary-rgb), 0.3);
   }
   100% {
-    background-color: rgba(33, 150, 243, 0.1);
+    background-color: rgba(var(--color-primary-rgb), 0.1);
   }
 }
 

--- a/src/components/chat/ChatEmptyState/ChatEmptyState.module.css
+++ b/src/components/chat/ChatEmptyState/ChatEmptyState.module.css
@@ -59,7 +59,7 @@
 }
 
 [data-mantine-color-scheme="dark"] .starterButton:hover {
-  background-color: rgba(33, 150, 243, 0.1);
+  background-color: rgba(var(--color-primary-rgb), 0.1);
   border-color: var(--color-primary-500);
   color: var(--color-primary-300);
 }

--- a/src/components/chat/ChatInput/ChatInput.module.css
+++ b/src/components/chat/ChatInput/ChatInput.module.css
@@ -22,7 +22,7 @@
 
 .inputOuterWrapper:focus-within {
   box-shadow:
-    0 0 0 3px rgba(33, 150, 243, 0.08),
+    0 0 0 3px rgba(var(--color-primary-rgb), 0.08),
     0 1px 2px 0 rgba(0, 0, 0, 0.05);
 }
 
@@ -46,8 +46,8 @@
   gap: var(--spacing-md);
   background: linear-gradient(
     135deg,
-    rgba(33, 150, 243, 0.1) 0%,
-    rgba(33, 150, 243, 0.05) 100%
+    rgba(var(--color-primary-rgb), 0.1) 0%,
+    rgba(var(--color-primary-rgb), 0.05) 100%
   );
   backdrop-filter: blur(8px);
   border: 3px dashed var(--color-primary-500);
@@ -61,19 +61,19 @@
   0%,
   100% {
     border-color: var(--color-primary-500);
-    box-shadow: 0 0 0 0 rgba(33, 150, 243, 0.4);
+    box-shadow: 0 0 0 0 rgba(var(--color-primary-rgb), 0.4);
   }
   50% {
     border-color: var(--color-primary-400);
-    box-shadow: 0 0 0 8px rgba(33, 150, 243, 0);
+    box-shadow: 0 0 0 8px rgba(var(--color-primary-rgb), 0);
   }
 }
 
 [data-mantine-color-scheme="dark"] .dragOverlay {
   background: linear-gradient(
     135deg,
-    rgba(33, 150, 243, 0.15) 0%,
-    rgba(33, 150, 243, 0.08) 100%
+    rgba(var(--color-primary-rgb), 0.15) 0%,
+    rgba(var(--color-primary-rgb), 0.08) 100%
   );
   color: var(--color-primary-400);
 }

--- a/src/components/chat/ChatView/ChatView.module.css
+++ b/src/components/chat/ChatView/ChatView.module.css
@@ -88,8 +88,8 @@
   justify-content: center;
   background: linear-gradient(
     135deg,
-    rgba(33, 150, 243, 0.08) 0%,
-    rgba(33, 150, 243, 0.04) 100%
+    rgba(var(--color-primary-rgb), 0.08) 0%,
+    rgba(var(--color-primary-rgb), 0.04) 100%
   );
   backdrop-filter: blur(12px);
   border: 3px dashed var(--color-primary-500);
@@ -111,11 +111,11 @@
   0%,
   100% {
     border-color: var(--color-primary-500);
-    box-shadow: inset 0 0 0 0 rgba(33, 150, 243, 0.2);
+    box-shadow: inset 0 0 0 0 rgba(var(--color-primary-rgb), 0.2);
   }
   50% {
     border-color: var(--color-primary-400);
-    box-shadow: inset 0 0 40px 10px rgba(33, 150, 243, 0.1);
+    box-shadow: inset 0 0 40px 10px rgba(var(--color-primary-rgb), 0.1);
   }
 }
 
@@ -130,14 +130,14 @@
 }
 
 .dropZoneContent svg {
-  filter: drop-shadow(0 4px 12px rgba(33, 150, 243, 0.3));
+  filter: drop-shadow(0 4px 12px rgba(var(--color-primary-rgb), 0.3));
 }
 
 [data-mantine-color-scheme="dark"] .dropZoneOverlay {
   background: linear-gradient(
     135deg,
-    rgba(33, 150, 243, 0.12) 0%,
-    rgba(33, 150, 243, 0.06) 100%
+    rgba(var(--color-primary-rgb), 0.12) 0%,
+    rgba(var(--color-primary-rgb), 0.06) 100%
   );
 }
 

--- a/src/components/common/AddPrincipalDialog/AddPrincipalDialog.module.css
+++ b/src/components/common/AddPrincipalDialog/AddPrincipalDialog.module.css
@@ -175,7 +175,7 @@
 }
 
 [data-mantine-color-scheme="dark"] .radioOptionSelected {
-  background-color: rgba(33, 150, 243, 0.1);
+  background-color: rgba(var(--color-primary-rgb), 0.1);
 }
 
 /* Role option styles - same as radioOption but for the new multi/single select */
@@ -203,5 +203,5 @@
 }
 
 [data-mantine-color-scheme="dark"] .roleOptionSelected {
-  background-color: rgba(33, 150, 243, 0.1);
+  background-color: rgba(var(--color-primary-rgb), 0.1);
 }

--- a/src/components/common/ContentCard/ContentCard.module.css
+++ b/src/components/common/ContentCard/ContentCard.module.css
@@ -13,7 +13,7 @@
   gap: var(--spacing-sm);
   padding: var(--spacing-sm) var(--spacing-lg);
   border-bottom: 1px solid var(--border-light);
-  background: linear-gradient(to right, rgba(33, 150, 243, 0.04), transparent);
+  background: linear-gradient(to right, rgba(var(--color-primary-rgb), 0.04), transparent);
 }
 
 .headerClickable {
@@ -24,8 +24,8 @@
 .headerClickable:hover {
   background: linear-gradient(
     to right,
-    rgba(33, 150, 243, 0.08),
-    rgba(33, 150, 243, 0.02)
+    rgba(var(--color-primary-rgb), 0.08),
+    rgba(var(--color-primary-rgb), 0.02)
   );
 }
 
@@ -59,18 +59,18 @@
 [data-mantine-color-scheme="dark"] .card {
   background: #292929;
   border-color: rgba(255, 255, 255, 0.06);
-  box-shadow: 0 2px 8px rgba(33, 150, 243, 0.12);
+  box-shadow: 0 2px 8px rgba(var(--color-primary-rgb), 0.12);
 }
 
 [data-mantine-color-scheme="dark"] .header {
-  background: linear-gradient(to right, rgba(33, 150, 243, 0.08), transparent);
+  background: linear-gradient(to right, rgba(var(--color-primary-rgb), 0.08), transparent);
   border-bottom-color: rgba(255, 255, 255, 0.04);
 }
 
 [data-mantine-color-scheme="dark"] .headerClickable:hover {
   background: linear-gradient(
     to right,
-    rgba(33, 150, 243, 0.14),
-    rgba(33, 150, 243, 0.04)
+    rgba(var(--color-primary-rgb), 0.14),
+    rgba(var(--color-primary-rgb), 0.04)
   );
 }

--- a/src/components/common/EditRolesDialog/EditRolesDialog.module.css
+++ b/src/components/common/EditRolesDialog/EditRolesDialog.module.css
@@ -50,5 +50,5 @@
 }
 
 [data-mantine-color-scheme="dark"] .roleOptionSelected {
-  background-color: rgba(33, 150, 243, 0.1);
+  background-color: rgba(var(--color-primary-rgb), 0.1);
 }

--- a/src/components/layout/Sidebar/Sidebar.module.css
+++ b/src/components/layout/Sidebar/Sidebar.module.css
@@ -76,7 +76,7 @@
 }
 
 [data-mantine-color-scheme="dark"] .navItemActive {
-  background-color: rgba(33, 150, 243, 0.06) !important;
+  background-color: rgba(var(--color-primary-rgb), 0.06) !important;
   color: var(--color-primary-300) !important;
   border-image: var(--gradient-accent) 1 !important;
   border-left-width: 4px !important;

--- a/src/components/tracing/TracingCanvasView.module.css
+++ b/src/components/tracing/TracingCanvasView.module.css
@@ -62,7 +62,7 @@
 .customNodeSelected {
   box-shadow: var(--shadow-md);
   border-width: 3px;
-  border-color: #1e88e5 !important; /* Primary blue - same as root chain arrows */
+  border-color: var(--color-primary-600) !important; /* Primary blue - same as root chain arrows */
 }
 
 .nodeIcon {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,6 +10,7 @@ import { AuthProvider, LdapAuthProvider, DebugAuthProvider } from './auth';
 import { OidcAuthProvider, OidcAuthProviderUnconfigured } from './auth/OidcAuthProvider';
 import { theme } from './theme';
 import { colorSchemeManager } from './theme/colorSchemeManager';
+import { applyThemeCssVariables } from './theme/cssVariables';
 import { IdentityProvider, SidebarDataProvider, AICapabilitiesProvider, FavoritesProvider, RecentVisitsProvider, NotificationProvider } from './contexts';
 import i18n from './i18n';
 import { initializeCustomExtension } from './extensions/registry';
@@ -21,6 +22,8 @@ import '@mantine/charts/styles.css';
 
 import './styles/variables.css';
 import './index.css';
+
+applyThemeCssVariables();
 
 const msalInstance = authConfig.microsoft ? new PublicClientApplication(msalConfig) : null;
 

--- a/src/pages/ConversationsPage/ConversationsPage.module.css
+++ b/src/pages/ConversationsPage/ConversationsPage.module.css
@@ -122,8 +122,8 @@
   justify-content: center;
   background: linear-gradient(
     135deg,
-    rgba(33, 150, 243, 0.08) 0%,
-    rgba(33, 150, 243, 0.04) 100%
+    rgba(var(--color-primary-rgb), 0.08) 0%,
+    rgba(var(--color-primary-rgb), 0.04) 100%
   );
   backdrop-filter: blur(12px);
   border: 3px dashed var(--color-primary-500);
@@ -145,11 +145,11 @@
   0%,
   100% {
     border-color: var(--color-primary-500);
-    box-shadow: inset 0 0 0 0 rgba(33, 150, 243, 0.2);
+    box-shadow: inset 0 0 0 0 rgba(var(--color-primary-rgb), 0.2);
   }
   50% {
     border-color: var(--color-primary-400);
-    box-shadow: inset 0 0 40px 10px rgba(33, 150, 243, 0.1);
+    box-shadow: inset 0 0 40px 10px rgba(var(--color-primary-rgb), 0.1);
   }
 }
 
@@ -164,14 +164,14 @@
 }
 
 .dropZoneContent svg {
-  filter: drop-shadow(0 4px 12px rgba(33, 150, 243, 0.3));
+  filter: drop-shadow(0 4px 12px rgba(var(--color-primary-rgb), 0.3));
 }
 
 [data-mantine-color-scheme="dark"] .dropZoneOverlay {
   background: linear-gradient(
     135deg,
-    rgba(33, 150, 243, 0.12) 0%,
-    rgba(33, 150, 243, 0.06) 100%
+    rgba(var(--color-primary-rgb), 0.12) 0%,
+    rgba(var(--color-primary-rgb), 0.06) 100%
   );
 }
 

--- a/src/pages/LoginPage/LoginPage.module.css
+++ b/src/pages/LoginPage/LoginPage.module.css
@@ -42,7 +42,7 @@
   width: 36px;
   height: 36px;
   border-radius: 8px;
-  background: linear-gradient(135deg, #2196f3, #9c27b0);
+  background: linear-gradient(135deg, var(--color-primary-500), var(--color-secondary-500));
   flex-shrink: 0;
 }
 

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -15,6 +15,8 @@
   --color-primary-700: #1976d2;
   --color-primary-800: #1565c0;
   --color-primary-900: #0d47a1;
+  /* RGB triple of --color-primary-500, for rgba() with custom alpha */
+  --color-primary-rgb: 33, 150, 243;
 
   /* ===== COLORS - SECONDARY ===== */
   --color-secondary-50: #f3e5f5;
@@ -196,9 +198,9 @@
   --border-error: var(--color-error-400);
 
   /* ===== INTERACTIVE STATES ===== */
-  --bg-hover: rgba(33, 150, 243, 0.1);
-  --bg-selected: rgba(33, 150, 243, 0.2);
-  --bg-selected-hover: rgba(33, 150, 243, 0.3);
+  --bg-hover: rgba(var(--color-primary-rgb), 0.1);
+  --bg-selected: rgba(var(--color-primary-rgb), 0.2);
+  --bg-selected-hover: rgba(var(--color-primary-rgb), 0.3);
 
   /* ===== ACCENT GRADIENT ===== */
   --gradient-accent: linear-gradient(

--- a/src/theme/cssVariables.ts
+++ b/src/theme/cssVariables.ts
@@ -1,0 +1,52 @@
+/**
+ * Theme CSS Custom Properties
+ *
+ * styles/variables.css ships the default palette as a static fallback, and the
+ * CSS modules across the app consume those variables. This module writes the
+ * *active* preset's shades onto the document root so that VITE_THEME_PRESET
+ * reaches plain CSS too, not just the Mantine components.
+ *
+ * Only the raw palette scales are written. Semantic variables (--text-link,
+ * --border-focus, --gradient-accent, …) already reference them and therefore
+ * follow automatically — and they stay in the stylesheet, so the light/dark
+ * rules keep working.
+ */
+
+import { colors } from './colors';
+
+/** CSS variable step names, in the order of a Mantine 10-shade tuple */
+const SHADE_STEPS = ['50', '100', '200', '300', '400', '500', '600', '700', '800', '900'] as const;
+
+/** Converts '#003893' to '0, 56, 147' for use in rgba(var(--…-rgb), <alpha>) */
+function hexToRgbTriple(hex: string): string | null {
+  const match = /^#([0-9a-f]{6})$/i.exec(hex.trim());
+  if (!match) return null;
+
+  const value = parseInt(match[1], 16);
+  return `${(value >> 16) & 255}, ${(value >> 8) & 255}, ${value & 255}`;
+}
+
+function applyScale(root: HTMLElement, name: string, shades: readonly string[]): void {
+  SHADE_STEPS.forEach((step, index) => {
+    const shade = shades[index];
+    if (shade) {
+      root.style.setProperty(`--color-${name}-${step}`, shade);
+    }
+  });
+}
+
+/**
+ * Writes the active preset's primary and secondary palettes to :root.
+ * Call once before the app renders.
+ */
+export function applyThemeCssVariables(): void {
+  const root = document.documentElement;
+
+  applyScale(root, 'primary', colors.primary);
+  applyScale(root, 'secondary', colors.secondary);
+
+  const primaryRgb = hexToRgbTriple(colors.primary[5]);
+  if (primaryRgb) {
+    root.style.setProperty('--color-primary-rgb', primaryRgb);
+  }
+}


### PR DESCRIPTION
## What

Wires the theme-preset system through to the CSS layer:

1. **`applyThemeCssVariables()`** (new, called once at startup): writes the active preset's primary/secondary colors onto `:root`, so `--color-primary-*` / `--color-secondary-*` always match the preset selected via `VITE_THEME_PRESET`.
2. Adds **`--color-primary-rgb`** for `rgba(var(--color-primary-rgb), …)` usage.
3. Replaces **38 hardcoded color literals** (36× `rgba(33, 150, 243, …)`, the logo fallback gradient, the tracing selection border) across 11 files with those variables.

## Why

`variables.css` pins `--color-primary-*` / `--color-secondary-*` statically to Material blue/purple. `VITE_THEME_PRESET` therefore only themes Mantine components, while the ~39 CSS modules keep the hardcoded palette — the preset system is only half wired. With this change a preset consistently colors buttons, links, sidebar states, focus rings, chat UI, dialogs, etc.

## Notes

- No visual change for the default preset — the resolved values are identical to the previous hardcoded ones.
- Known leftover (intentionally untouched): `TracingCanvasView.tsx` passes `#1e88e5` three times as JS props into the graph library; that path doesn't go through CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)