### PR TITLE
fix(branding): apply app title and favicon to the document

### DIFF
--- a/src/config/documentBranding.ts
+++ b/src/config/documentBranding.ts
@@ -1,0 +1,37 @@
+/**
+ * Document Branding
+ *
+ * index.html carries the default title and favicon as static markup. This
+ * module applies the active branding to the document itself, so VITE_APP_TITLE
+ * and the branding's faviconUrl reach the browser tab instead of only the
+ * in-app header.
+ */
+
+import { activeBranding, APP_TITLE } from './branding.config';
+
+function applyFavicon(faviconUrl: string): void {
+  const existing = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
+
+  if (existing) {
+    existing.href = faviconUrl;
+    return;
+  }
+
+  const link = document.createElement('link');
+  link.rel = 'icon';
+  link.type = 'image/svg+xml';
+  link.href = faviconUrl;
+  document.head.appendChild(link);
+}
+
+/**
+ * Applies title and favicon from the active branding.
+ * Call once before the app renders.
+ */
+export function applyDocumentBranding(): void {
+  document.title = APP_TITLE;
+
+  if (activeBranding.faviconUrl) {
+    applyFavicon(activeBranding.faviconUrl);
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,6 +10,7 @@ import { AuthProvider, LdapAuthProvider, DebugAuthProvider } from './auth';
 import { OidcAuthProvider, OidcAuthProviderUnconfigured } from './auth/OidcAuthProvider';
 import { theme } from './theme';
 import { colorSchemeManager } from './theme/colorSchemeManager';
+import { applyDocumentBranding } from './config/documentBranding';
 import { IdentityProvider, SidebarDataProvider, AICapabilitiesProvider, FavoritesProvider, RecentVisitsProvider, NotificationProvider } from './contexts';
 import i18n from './i18n';
 import { initializeCustomExtension } from './extensions/registry';
@@ -21,6 +22,8 @@ import '@mantine/charts/styles.css';
 
 import './styles/variables.css';
 import './index.css';
+
+applyDocumentBranding();
 
 const msalInstance = authConfig.microsoft ? new PublicClientApplication(msalConfig) : null;
 


### PR DESCRIPTION
## What

Adds `applyDocumentBranding()` (called once at startup) which sets:

1. **`document.title`** from `VITE_APP_TITLE`
2. **the favicon** from the active branding's `faviconUrl`

## Why

Both are currently hardcoded in `index.html`, so the browser tab always shows "unified-ui" with the default icon even when a branding is active. `faviconUrl` already exists in the branding config but was declared and never applied.

## Notes

- No-op when `VITE_APP_TITLE` / `faviconUrl` are unset — current behavior is preserved exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)